### PR TITLE
fix: Remove unused argument

### DIFF
--- a/chisel-template/src/main/scala/03_lw/Memory.scala
+++ b/chisel-template/src/main/scala/03_lw/Memory.scala
@@ -15,7 +15,7 @@ class DmemPortIo extends Bundle {
   val rdata = Output(UInt(WORD_LEN.W))
 }
 
-class Memory(hex: String) extends Module {
+class Memory extends Module {
   val io = IO(new Bundle {
     val imem = new ImemPortIo()
     val dmem = new DmemPortIo() // 追加

--- a/chisel-template/src/main/scala/03_lw/Top.scala
+++ b/chisel-template/src/main/scala/03_lw/Top.scala
@@ -8,7 +8,7 @@ class Top extends Module {
     val exit = Output(Bool())
   })
   val core = Module(new Core())
-  val memory = Module(new Memory("src/c/lw.hex"))
+  val memory = Module(new Memory())
   core.io.imem <> memory.io.imem
   core.io.dmem <> memory.io.dmem
   io.exit := core.io.exit


### PR DESCRIPTION
Remove unused argument in 03_lw.
This is because the path to `lw.hex` is written directly in `Memory.scala`.