### PR TITLE
Remove unused imports in the common directory

### DIFF
--- a/chisel-template/src/main/scala/common/Consts.scala
+++ b/chisel-template/src/main/scala/common/Consts.scala
@@ -1,7 +1,6 @@
 package common
 
 import chisel3._
-import chisel3.util._
 
 object Consts {
   val WORD_LEN      = 32

--- a/chisel-template/src/main/scala/common/Instructions.scala
+++ b/chisel-template/src/main/scala/common/Instructions.scala
@@ -1,6 +1,5 @@
 package common
 
-import chisel3._
 import chisel3.util._
 
 object Instructions {


### PR DESCRIPTION
Hi, thank you for the great book! I've just started to read the one.

I found that there seems to be lots of unused imports either `chisel3._` or `chisel3.util._`. I removed them in the `common` package and build the whole project then it seems to work fine. I imported the project into IntelliJ Idea and detected them.

Leaving unused imports makes readers a bit confused, so I suppose we should remove them correctly. If so, I'll remove them in other directories as far as I can find.

What do you think? If you have any other intentions regarding these imports, please discard this Pull Request.